### PR TITLE
fix: update tag-and-release-workflow

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -26,7 +26,7 @@ jobs:
        github.event.pull_request.labels.*.name != 'version:patch') ||
       (github.event_name == 'push' &&
        github.ref == 'refs/heads/main' &&
-       !contains(github.event.head_commit.message, 'Merge pull request'))
+       !startsWith(github.event.head_commit.message, 'Merge pull request'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- ensure that the workflow only run once